### PR TITLE
Switched error to use thiserror

### DIFF
--- a/rpos_drv/Cargo.toml
+++ b/rpos_drv/Cargo.toml
@@ -9,4 +9,4 @@ authors = ["Tony Huang <tony@slamtec.com>"]
 edition = "2018"
 
 [dependencies]
-failure = "0.1.5"
+thiserror = "2.0"

--- a/rpos_drv/src/errors.rs
+++ b/rpos_drv/src/errors.rs
@@ -1,30 +1,24 @@
-pub use failure::{ Fail, Error };
-
-#[derive(Fail, Debug)]
+#[derive(thiserror::Error, Debug)]
 pub enum RposError {
     /// The execution of operation failed
-    #[fail(display="operation failed: {}", description)]
-    OperationFail {
-        description: String
-    },
+    #[error("operation failed: {}", description)]
+    OperationFail { description: String },
 
     /// The execution of operation is timed out
-    #[fail(display="operation timeout")]
+    #[error("operation timeout")]
     OperationTimeout,
 
     /// The device doesn't support this operation
-    #[fail(display="operation not support")]
+    #[error("operation not support")]
     OperationNotSupport,
 
     /// The decoding data is invalid according to current protocol
-    #[fail(display="protocol error: {}", description)]
-    ProtocolError {
-        description: String
-    },
+    #[error("protocol error: {}", description)]
+    ProtocolError { description: String },
 
     /// The buffer is too small for message encoding
-    #[fail(display="buffer is too small for message encoding")]
-    BufferTooSmall
+    #[error("buffer is too small for message encoding")]
+    BufferTooSmall,
 }
 
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T> = std::result::Result<T, RposError>;


### PR DESCRIPTION
Current errors make use of the `failure` crate, a now archived crate whose errors don't implement `std::error::Error`, making it difficult to work with errors in other parts of the language. This PR switches to using `thiserror` entirely. This is a breaking change so would require bumping minor versions on both crates.